### PR TITLE
PHP Notice "Trying to get property of non-object" on post editing page

### DIFF
--- a/inclusive-parents.php
+++ b/inclusive-parents.php
@@ -91,7 +91,7 @@ add_filter( 'the_title', 'scl_menu_checklist_status_label', 10, 2 );
  * @return object $query
  */
 function scl_menu_screen_add_private_pages( $query ) {
-	if ( is_admin() && 'nav-menus' == get_current_screen()->base ) {
+	if ( is_admin() && ($screen = get_current_screen()) && 'nav-menus' == $screen->base ) {
 		$query->set( 'post_status', array( 'publish', 'private', 'password' ) );
 	}	
 	return $query;


### PR DESCRIPTION
When accessing the post/page editing page in the WordPress backend, there is a PHP Notice at the beginning of the page:

```
Notice: Trying to get property of non-object
in /wp-content/plugins/inclusive-parents/inclusive-parents.php on line 94
```

This PR fixes that issue.
